### PR TITLE
feat(ci): ubuntu workflow skeleton (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      extension: ${{ steps.filter.outputs.extension }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            extension:
+              - 'packages/extension/**'
+              - 'packages/shared/**'
+              - '.github/workflows/ci.yml'
+              - 'package.json'
+              - 'bun.lock'
+
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Cache bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Lint
+        run: bun run lint
+      - name: Format check
+        run: bun run format:check
+      - name: Build extension
+        run: bun run compile
+        working-directory: packages/extension
+
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Cache bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run unit tests
+        run: bun --filter '*' test


### PR DESCRIPTION
## Summary

Implements #63 — first slice of `.github/workflows/ci.yml` with three ubuntu jobs: `changes` (path-filter detect), `quality` (typecheck + lint + format:check + build), `unit` (vitest across all packages).

## Test plan

- [ ] CI runs on this PR and shows three jobs
- [ ] `quality` job exposes any pre-existing typecheck/lint/format failures in `packages/electron-app` and `packages/cli` — those are tracked separately, not blockers for the workflow itself
- [ ] `unit` job runs the existing 371 vitest tests
- [ ] `changes` job exposes `extension` boolean output for #64 to consume

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)