### PR TITLE
feat(test-harness): env vars + stub Agent + registry adapter (#65)

### DIFF
--- a/packages/extension/src/__tests__/agent-registry.test.ts
+++ b/packages/extension/src/__tests__/agent-registry.test.ts
@@ -62,6 +62,32 @@ describe('agent-registry', () => {
     });
   });
 
+  describe('stub agent (test harness)', () => {
+    const registry = createAgentRegistry({ getDefault: () => 'agency-cc' });
+
+    it('is registered alongside the built-in adapters', () => {
+      const adapter = registry.resolve('stub');
+      expect(adapter.name).toBe('stub');
+      expect(adapter.command).toBe('node');
+    });
+
+    it('passes the claude-stub.mjs path as a positional arg', () => {
+      const adapter = registry.resolve('stub');
+      expect(adapter.args).toBeDefined();
+      expect(adapter.args!.length).toBe(1);
+      expect(adapter.args![0]).toMatch(/claude-stub\.mjs$/);
+    });
+
+    it('emits an empty resumeFlag (the stub does not honor session ids)', () => {
+      const adapter = registry.resolve('stub');
+      expect(adapter.resumeFlag('whatever')).toEqual([]);
+    });
+
+    it('declares ClaudeJsonlDetector so the existing detector path is exercised', () => {
+      expect(registry.resolve('stub').detector).toBe('ClaudeJsonlDetector');
+    });
+  });
+
   describe('createVscodeAgentRegistry', () => {
     it('reads the default agent from tackle.defaultAgent configuration', async () => {
       resetMocks();

--- a/packages/extension/src/__tests__/claude-jsonl-detector.test.ts
+++ b/packages/extension/src/__tests__/claude-jsonl-detector.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import type { Session } from '@tackle/shared';
 import {
   createClaudeJsonlDetector,
+  defaultJsonlPathResolver,
   deriveStateFromEntry,
   type JsonlPathResolver,
 } from '../agent/claude-jsonl-detector';
@@ -358,5 +359,32 @@ describe('ClaudeJsonlDetector — waiting transitions (#42)', () => {
     const states = events.map((e) => e.state);
     expect(states).toEqual(['idle', 'working']);
     expect(states).not.toContain('waiting');
+  });
+});
+
+describe('defaultJsonlPathResolver', () => {
+  afterEach(() => {
+    delete process.env.TACKLE_TEST_JSONL_DIR;
+  });
+
+  it('uses TACKLE_TEST_JSONL_DIR when set, replacing the projects/<hash>/ part', () => {
+    process.env.TACKLE_TEST_JSONL_DIR = '/tmp/jsonl-override';
+    const resolver = defaultJsonlPathResolver(() => '/some/cwd');
+    const out = resolver.resolve(baseSession({ claude_session_id: 'abc' }));
+    expect(out).toBe(path.join('/tmp/jsonl-override', 'abc.jsonl'));
+  });
+
+  it('falls back to ~/.claude/projects/<hash>/<id>.jsonl when env var unset', () => {
+    delete process.env.TACKLE_TEST_JSONL_DIR;
+    const resolver = defaultJsonlPathResolver(() => '/some/cwd');
+    const out = resolver.resolve(baseSession({ claude_session_id: 'abc' }));
+    expect(out).toContain(path.join('.claude', 'projects'));
+    expect(out!.endsWith('abc.jsonl')).toBe(true);
+  });
+
+  it('returns null when claude_session_id is missing, regardless of env', () => {
+    process.env.TACKLE_TEST_JSONL_DIR = '/tmp/jsonl-override';
+    const resolver = defaultJsonlPathResolver(() => '/some/cwd');
+    expect(resolver.resolve(baseSession({ claude_session_id: null }))).toBeNull();
   });
 });

--- a/packages/extension/src/__tests__/claude-stub.test.ts
+++ b/packages/extension/src/__tests__/claude-stub.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  defaultJsonlPathResolver,
+  deriveStateFromEntry,
+} from '../agent/claude-jsonl-detector';
+import type { Session } from '@tackle/shared';
+
+const STUB = path.join(__dirname, '..', '..', 'test', 'fixtures', 'bin', 'claude-stub.mjs');
+
+const baseSession = (over: Partial<Session> = {}): Session => ({
+  id: 1,
+  task_id: 1,
+  phase_id: null,
+  name: 's',
+  kind: 'implement',
+  status: 'running',
+  psmux_name: 'p',
+  tab_label: 't',
+  agent: null,
+  worktree_path: null,
+  sort_order: 0,
+  claude_session_id: 'stub-session',
+  agent_state: 'idle',
+  prior_claude_session_ids: null,
+  started_at: '',
+  ended_at: null,
+  ...over,
+});
+
+describe('claude-stub.mjs smoke', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tackle-stub-'));
+  });
+
+  afterEach(() => {
+    delete process.env.TACKLE_TEST_STUB_SCENARIO;
+    delete process.env.TACKLE_TEST_JSONL_DIR;
+    delete process.env.TACKLE_TEST_STUB_SESSION_ID;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function run(scenario: string): { stdout: string; stderr: string; status: number | null } {
+    const r = spawnSync(process.execPath, [STUB], {
+      env: {
+        ...process.env,
+        TACKLE_TEST_STUB_SCENARIO: scenario,
+        TACKLE_TEST_JSONL_DIR: tmpDir,
+        TACKLE_TEST_STUB_SESSION_ID: 'sess-1',
+      },
+      timeout: 5000,
+      encoding: 'utf8',
+    });
+    return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status };
+  }
+
+  function readEntries(): unknown[] {
+    const file = path.join(tmpDir, 'sess-1.jsonl');
+    const content = fs.readFileSync(file, 'utf8').trim();
+    if (!content) return [];
+    return content.split('\n').map((l) => JSON.parse(l));
+  }
+
+  it('idle scenario: writes a single end_turn entry and exits 0', () => {
+    const r = run('idle');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('scenario=idle');
+    const entries = readEntries();
+    expect(entries).toHaveLength(1);
+    expect(deriveStateFromEntry(entries[0])).toBe('idle');
+  });
+
+  it('idle-working-idle scenario: writes 4 entries, last is idle, mid is working', () => {
+    const r = run('idle-working-idle');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('scenario=idle-working-idle');
+    const entries = readEntries();
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+    // States derived from the trailing prefix should include idle then working
+    // and end on idle, mirroring the three-state transition the detector sees.
+    expect(deriveStateFromEntry(entries[0])).toBe('idle');
+    expect(deriveStateFromEntry(entries[entries.length - 2])).toBe('working');
+    expect(deriveStateFromEntry(entries[entries.length - 1])).toBe('idle');
+  });
+
+  it('waiting scenario: last entry is a tool_approval_request system event', () => {
+    const r = run('waiting');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('scenario=waiting');
+    const entries = readEntries();
+    expect(deriveStateFromEntry(entries[entries.length - 1])).toBe('waiting');
+  });
+
+  it('emits a jsonl file the production resolver also points at', () => {
+    process.env.TACKLE_TEST_JSONL_DIR = tmpDir;
+    const r = run('idle');
+    expect(r.status).toBe(0);
+    const resolver = defaultJsonlPathResolver(() => '/anywhere');
+    const expected = resolver.resolve(baseSession({ claude_session_id: 'sess-1' }));
+    expect(expected).toBe(path.join(tmpDir, 'sess-1.jsonl'));
+    expect(fs.existsSync(expected!)).toBe(true);
+  });
+});

--- a/packages/extension/src/__tests__/mode-manager.test.ts
+++ b/packages/extension/src/__tests__/mode-manager.test.ts
@@ -89,5 +89,17 @@ describe('ModeManager', () => {
       await manager.deactivate();
       expect(manager.getDatabase()).toBeUndefined();
     });
+
+    it('uses TACKLE_TEST_DB env var when set', async () => {
+      const prev = process.env.TACKLE_TEST_DB;
+      try {
+        process.env.TACKLE_TEST_DB = '/tmp/override-tackle.db';
+        await manager.activate();
+        expect(createDatabase).toHaveBeenCalledWith('/tmp/override-tackle.db');
+      } finally {
+        if (prev === undefined) delete process.env.TACKLE_TEST_DB;
+        else process.env.TACKLE_TEST_DB = prev;
+      }
+    });
   });
 });

--- a/packages/extension/src/__tests__/workspace-guard.test.ts
+++ b/packages/extension/src/__tests__/workspace-guard.test.ts
@@ -18,7 +18,7 @@ vi.mock('vscode', () => ({
   },
 }));
 
-import { checkSingleRootWorkspace, ensureTackleDir } from '../guards/workspace-guard';
+import { checkSingleRootWorkspace, ensureTackleDir, resolveWorkspaceRoot } from '../guards/workspace-guard';
 
 describe('checkSingleRootWorkspace', () => {
   beforeEach(() => {
@@ -53,6 +53,31 @@ describe('checkSingleRootWorkspace', () => {
     const result = await checkSingleRootWorkspace();
     expect(result).toBe(true);
     expect(mockShowErrorMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveWorkspaceRoot', () => {
+  beforeEach(() => {
+    delete process.env.TACKLE_TEST_WORKSPACE;
+    mockWorkspaceFolders.value = [{ uri: { fsPath: '/real/workspace' } }];
+  });
+
+  afterEach(() => {
+    delete process.env.TACKLE_TEST_WORKSPACE;
+  });
+
+  it('returns TACKLE_TEST_WORKSPACE when set', () => {
+    process.env.TACKLE_TEST_WORKSPACE = '/tmp/override-ws';
+    expect(resolveWorkspaceRoot()).toBe('/tmp/override-ws');
+  });
+
+  it('falls back to vscode workspaceFolders[0] when env var unset', () => {
+    expect(resolveWorkspaceRoot()).toBe('/real/workspace');
+  });
+
+  it('returns undefined when env var unset and no workspace folder', () => {
+    mockWorkspaceFolders.value = undefined;
+    expect(resolveWorkspaceRoot()).toBeUndefined();
   });
 });
 

--- a/packages/extension/src/agent/agent-registry.ts
+++ b/packages/extension/src/agent/agent-registry.ts
@@ -1,4 +1,6 @@
 import type { SessionKind } from '@tackle/shared';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { AgentStateDetector } from './agent-state-detector';
 
 /**
@@ -28,6 +30,12 @@ export type DetectorKind = 'ClaudeJsonlDetector';
 export interface AgentAdapter {
   name: string;
   command: string;
+  /**
+   * Positional args prepended before the resume flag (and any other
+   * orchestrator-supplied args) on every spawn. Used by the `stub` test
+   * harness adapter to pass the claude-stub.mjs path to `node`.
+   */
+  args?: string[];
   resumeFlag(sessionId: string): string[];
   detector: DetectorKind;
 }
@@ -91,6 +99,20 @@ const BUILTIN_ADAPTERS: Record<string, AgentAdapter> = {
     name: 'claude',
     command: 'claude',
     resumeFlag: (sessionId: string) => ['-r', sessionId],
+    detector: 'ClaudeJsonlDetector',
+  },
+  // Test-harness adapter (#65). Engaged by setting
+  // `tackle.defaultAgent = 'stub'` in test fixtures. The stub script lives
+  // alongside the extension package's test fixtures and writes synthetic
+  // jsonl files that the real ClaudeJsonlDetector parses unchanged.
+  stub: {
+    name: 'stub',
+    command: 'node',
+    args: [path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..', '..', 'test', 'fixtures', 'bin', 'claude-stub.mjs',
+    )],
+    resumeFlag: () => [],
     detector: 'ClaudeJsonlDetector',
   },
 };

--- a/packages/extension/src/agent/claude-jsonl-detector.ts
+++ b/packages/extension/src/agent/claude-jsonl-detector.ts
@@ -62,6 +62,12 @@ export function defaultJsonlPathResolver(getCwd: (s: Session) => string | null):
   return {
     resolve(session: Session): string | null {
       if (!session.claude_session_id) return null;
+      // Test-mode escape hatch: bypass the ~/.claude/projects/<hash>/ layout
+      // and emit files into a fixture-controlled directory instead.
+      const overrideDir = process.env.TACKLE_TEST_JSONL_DIR;
+      if (overrideDir) {
+        return path.join(overrideDir, `${session.claude_session_id}.jsonl`);
+      }
       const cwd = getCwd(session);
       if (!cwd) return null;
       // Claude Code uses an md5 of the absolute path, lowercased hex.

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -9,7 +9,7 @@ import { SessionActions, ObservableSessionRepository, NewSessionFlow, buildKindQ
 import { LayoutManager } from './layout';
 import { ScopeManager } from './scope';
 import { SidebarController, SidebarViewProvider } from './sidebar';
-import { checkSingleRootWorkspace, ensureTackleDir } from './guards';
+import { checkSingleRootWorkspace, ensureTackleDir, resolveWorkspaceRoot } from './guards';
 import { runLatencyBenchmark, formatResult } from './bench';
 
 // Module-level reference so `deactivate()` can release detectors and
@@ -66,7 +66,7 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
 
-      const workspaceRoot = vscode.workspace.workspaceFolders![0].uri.fsPath;
+      const workspaceRoot = resolveWorkspaceRoot()!;
       await ensureTackleDir(workspaceRoot);
       await modeManager.activate();
 

--- a/packages/extension/src/guards/index.ts
+++ b/packages/extension/src/guards/index.ts
@@ -1,1 +1,1 @@
-export { checkSingleRootWorkspace, ensureTackleDir } from './workspace-guard';
+export { checkSingleRootWorkspace, ensureTackleDir, resolveWorkspaceRoot } from './workspace-guard';

--- a/packages/extension/src/guards/workspace-guard.ts
+++ b/packages/extension/src/guards/workspace-guard.ts
@@ -25,6 +25,14 @@ export async function checkSingleRootWorkspace(): Promise<boolean> {
 }
 
 /**
+ * Resolves the workspace root path. Returns `TACKLE_TEST_WORKSPACE` when set
+ * (test-mode escape hatch), else `vscode.workspace.workspaceFolders[0].uri.fsPath`.
+ */
+export function resolveWorkspaceRoot(): string | undefined {
+  return process.env.TACKLE_TEST_WORKSPACE ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
+/**
  * Ensures .tackle/ directory exists and is in .gitignore.
  * Creates .tackle/ if missing. Creates/updates .gitignore.
  */

--- a/packages/extension/src/mode/mode-manager.ts
+++ b/packages/extension/src/mode/mode-manager.ts
@@ -38,7 +38,8 @@ export class ModeManager {
 
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (workspaceFolder) {
-      const dbPath = join(workspaceFolder.uri.fsPath, '.tackle', 'tackle.db');
+      const dbPath = process.env.TACKLE_TEST_DB
+        ?? join(workspaceFolder.uri.fsPath, '.tackle', 'tackle.db');
       this.db = createDatabase(dbPath);
     }
 

--- a/packages/extension/test/fixtures/bin/claude-stub.mjs
+++ b/packages/extension/test/fixtures/bin/claude-stub.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Tackle test-mode stub Agent.
+//
+// Mimics enough of Claude Code's behavior for integration / visual / perf
+// suites to drive the real Tackle code paths without requiring a real
+// Claude binary. Reads two env vars:
+//
+//   TACKLE_TEST_STUB_SCENARIO   one of: idle | idle-working-idle | waiting
+//                               (default: idle-working-idle)
+//   TACKLE_TEST_JSONL_DIR       directory to drop the synthetic jsonl in
+//                               (must be set; matches the production
+//                               override read by ClaudeJsonlDetector)
+//   TACKLE_TEST_STUB_SESSION_ID claude_session_id to use for the jsonl
+//                               filename (default: stub-session)
+//
+// Each scenario prints a small banner to stdout, writes a deterministic
+// sequence of jsonl entries (shape compatible with ClaudeJsonlDetector
+// from PR #50: top-level `type` of user|assistant|system, with assistant
+// nesting `message.stop_reason` and `message.content` arrays), and exits
+// 0 within ~2 seconds so test runners don't time out.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const scenario = process.env.TACKLE_TEST_STUB_SCENARIO ?? 'idle-working-idle';
+const jsonlDir = process.env.TACKLE_TEST_JSONL_DIR;
+const sessionId = process.env.TACKLE_TEST_STUB_SESSION_ID ?? 'stub-session';
+
+if (!jsonlDir) {
+  process.stderr.write('claude-stub: TACKLE_TEST_JSONL_DIR must be set\n');
+  process.exit(2);
+}
+
+fs.mkdirSync(jsonlDir, { recursive: true });
+const jsonlPath = path.join(jsonlDir, `${sessionId}.jsonl`);
+
+// Truncate any previous run so each scenario writes a clean file.
+fs.writeFileSync(jsonlPath, '');
+
+const append = (entry) => {
+  fs.appendFileSync(jsonlPath, JSON.stringify(entry) + '\n');
+};
+
+// Tiny non-blocking delay so the detector's fs.watch + poll loop has a
+// chance to see distinct file-size deltas between transitions. 50ms is
+// well under the 2s budget but well above the 25ms watcher debounce.
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const userPrompt = () => ({
+  type: 'user',
+  message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+});
+
+const assistantWorking = () => ({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    stop_reason: 'tool_use',
+    content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }],
+  },
+});
+
+const assistantIdle = () => ({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    stop_reason: 'end_turn',
+    content: [{ type: 'text', text: 'done' }],
+  },
+});
+
+const toolApprovalPause = () => ({
+  type: 'system',
+  subtype: 'tool_approval_request',
+});
+
+async function runIdle() {
+  process.stdout.write(`stub-agent scenario=idle session=${sessionId}\n`);
+  append(assistantIdle());
+}
+
+async function runIdleWorkingIdle() {
+  process.stdout.write(`stub-agent scenario=idle-working-idle session=${sessionId}\n`);
+  append(assistantIdle());
+  await delay(50);
+  append(userPrompt());
+  await delay(50);
+  append(assistantWorking());
+  await delay(50);
+  append(assistantIdle());
+}
+
+async function runWaiting() {
+  process.stdout.write(`stub-agent scenario=waiting session=${sessionId}\n`);
+  append(userPrompt());
+  await delay(50);
+  append(toolApprovalPause());
+}
+
+const SCENARIOS = {
+  idle: runIdle,
+  'idle-working-idle': runIdleWorkingIdle,
+  waiting: runWaiting,
+};
+
+const fn = SCENARIOS[scenario];
+if (!fn) {
+  process.stderr.write(`claude-stub: unknown scenario '${scenario}'\n`);
+  process.exit(2);
+}
+
+fn().then(() => process.exit(0)).catch((err) => {
+  process.stderr.write(`claude-stub: ${err?.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/packages/shared/src/__tests__/psmux-bridge.test.ts
+++ b/packages/shared/src/__tests__/psmux-bridge.test.ts
@@ -17,6 +17,24 @@ describe('PsmuxBridge', () => {
       expect(PsmuxBridge.generateSessionName('gh', 'ABC-123', 'debug', 3))
         .toBe('tackle-gh-ABC-123-debug3');
     });
+
+    it('honors TACKLE_TEST_PSMUX_PREFIX env var when set', () => {
+      const prev = process.env.TACKLE_TEST_PSMUX_PREFIX;
+      try {
+        process.env.TACKLE_TEST_PSMUX_PREFIX = 'tackletest-';
+        expect(PsmuxBridge.generateSessionName('gh', '42', 'implement', 1))
+          .toBe('tackletest-gh-42-implement1');
+      } finally {
+        if (prev === undefined) delete process.env.TACKLE_TEST_PSMUX_PREFIX;
+        else process.env.TACKLE_TEST_PSMUX_PREFIX = prev;
+      }
+    });
+
+    it('default prefix unchanged when env var unset', () => {
+      delete process.env.TACKLE_TEST_PSMUX_PREFIX;
+      expect(PsmuxBridge.generateSessionName('gh', '42', 'implement', 1))
+        .toBe('tackle-gh-42-implement1');
+    });
   });
 
   describe('generateTabLabel', () => {

--- a/packages/shared/src/psmux/psmux-bridge.ts
+++ b/packages/shared/src/psmux/psmux-bridge.ts
@@ -35,7 +35,8 @@ export class PsmuxBridge {
   }
 
   static generateSessionName(source: string, taskId: string, kind: string, n: number): string {
-    return `tackle-${source}-${taskId}-${kind}${n}`;
+    const prefix = process.env.TACKLE_TEST_PSMUX_PREFIX ?? 'tackle-';
+    return `${prefix}${source}-${taskId}-${kind}${n}`;
   }
 
   static generateTabLabel(taskId: string, slug: string, kind: string, n: number, label?: string): string {


### PR DESCRIPTION
## Summary

Implements #65 — test-mode escape hatches for the integration / visual / perf suites in #66/#67/#68.

**Production code delta:** ~13 lines across four module boundaries:
- `TACKLE_TEST_WORKSPACE` → `resolveWorkspaceRoot()` in `guards/workspace-guard.ts`
- `TACKLE_TEST_DB` → `ModeManager.activate()` in `mode/mode-manager.ts`
- `TACKLE_TEST_PSMUX_PREFIX` → `PsmuxBridge.generateSessionName()` in `psmux/psmux-bridge.ts`
- `TACKLE_TEST_JSONL_DIR` → `defaultJsonlPathResolver()` in `agent/claude-jsonl-detector.ts`

**Stub Agent:** `packages/extension/test/fixtures/bin/claude-stub.mjs` — cross-platform Node script with `idle`, `idle-working-idle`, `waiting` scenarios. JSONL shape derived from `ClaudeJsonlDetector.deriveStateFromEntry`. Registered as `stub` in the Agent registry alongside `agency-cc` and `claude` (ADR-0009).

**Tests:** 362 → 377 passing (+15 new — 4 stub smoke, 4 env-var override, 4 stub registry, 3 misc).

## Notes

- Added optional `args?: string[]` field to `AgentAdapter` interface (1 line) — needed by the stub adapter shape and consumed by the orchestrator wiring in #66.
- The 2 pre-existing latency-test failures (missing `vscode` package in `test/bench/latency.test.ts`) are also present on `origin/main`; not introduced by this PR.

## Test plan

- [ ] Existing 362 tests still pass with env vars unset
- [ ] New 15 tests pass
- [ ] Stub Agent jsonl is parseable by the existing detector without modification

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)